### PR TITLE
Add 'Login with Spotify' authentication flow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,6 +324,7 @@ dist
 # Django stuff:
 
 # Flask stuff:
+.flask_session
 
 # Scrapy stuff:
 

--- a/SimmerTheToads/__init__.py
+++ b/SimmerTheToads/__init__.py
@@ -1,6 +1,14 @@
+import os
+
 from flask import Flask
+from flask_session import Session
 
 app = Flask(__name__)
+app.config["SECRET_KEY"] = os.urandom(64)
+app.config["SESSION_TYPE"] = "filesystem"
+app.config["SESSION_FILE_DIR"] = "./.flask_session"
+Session(app)
+
 
 from .views import index
 

--- a/SimmerTheToads/templates/info.html
+++ b/SimmerTheToads/templates/info.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html class="no-js" lang="">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Login</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <!-- Place favicon.ico in the root directory -->
+
+</head>
+
+<body>
+    <!--[if lt IE 8]>
+            <p class="browserupgrade">
+            You are using an <strong>outdated</strong> browser. Please
+            <a href="http://browsehappy.com/">upgrade your browser</a> to improve
+            your experience.
+            </p>
+        <![endif]-->
+
+    <h2>Hi {{ display_name }}
+        <small><a href="/logout">[log out]</a></small>
+    </h2>
+    <a href="/playlists">My playlists</a>
+
+</body>
+
+</html>

--- a/SimmerTheToads/views.py
+++ b/SimmerTheToads/views.py
@@ -1,9 +1,142 @@
-from flask import render_template
+"""Contains all the 'views' that the flask application itself uses."""
+import functools
+import os
+
+import spotipy
+from flask import redirect, render_template, request, session
+from spotipy.oauth2 import SpotifyOAuth
 
 from . import app
+
+# Retrieve these values from the spotify developer dashboard:
+#   https://developer.spotify.com/dashboard/applications
+#
+# Set these in either .env or as environment variables
+CLIENT_ID = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+
+# This needs to be set in your spotify dashboard!
+REDIRECT_URI = "http://localhost:5000/login_callback"
+OAUTH_SCOPES = [
+    "playlist-read-private",
+    "playlist-read-collaborative",
+    "playlist-modify-private",
+    "playlist-modify-public",
+]
+
+
+def logged_in(func):
+    """Ensure a user is logged in before using that endpoint.
+
+    When used as a decarator, this function will automatically redirect to the
+    login endpoint if there is no cached user login available. If there is a
+    user logged in, the request is passed transparently to the function, along
+    with an authenticated spotipy.Client.Spotify object.
+
+    :param func: Function to guard against unauthenticate usage
+    :returns: func
+
+    Sample usage:
+
+        @app.route("/my-cool-endpoint")
+        @logged_in
+        def my_endpoint(spotify): # This parameter is required!
+            . . .
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        cache_handler = spotipy.cache_handler.FlaskSessionCacheHandler(session)
+        auth_manager = SpotifyOAuth(
+            cache_handler=cache_handler,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            redirect_uri=REDIRECT_URI,
+        )
+        if not auth_manager.validate_token(cache_handler.get_cached_token()):
+            return redirect("/login")
+
+        spotify = spotipy.Spotify(auth_manager=auth_manager)
+        return func(*args, **kwargs, spotify=spotify)
+
+    return wrapper
 
 
 @app.route("/")
 def index():
-    """Demo root index."""
+    """Landing page."""
     return render_template("index.html")
+
+
+@app.route("/login")
+def login():
+    """Login to spotify's API using OAuth2.
+
+    More documentation available here:
+        * https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
+        * https://github.com/spotipy-dev/spotipy/blob/master/examples/app.py
+    """
+    cache_handler = spotipy.cache_handler.FlaskSessionCacheHandler(session)
+    auth_manager = SpotifyOAuth(
+        scope=" ".join(OAUTH_SCOPES),
+        cache_handler=cache_handler,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        show_dialog=True,
+    )
+
+    if not auth_manager.validate_token(cache_handler.get_cached_token()):
+        # Step 1: Redirect to spotify OAuth when not logged in.
+        auth_url = auth_manager.get_authorize_url()
+        return redirect(auth_url)
+
+    return redirect("/info")
+
+
+@app.route("/login_callback")
+def login_callback():
+    """Endpoint to receive token from Spotify's redirect."""
+    cache_handler = spotipy.cache_handler.FlaskSessionCacheHandler(session)
+    auth_manager = SpotifyOAuth(
+        scope=" ".join(OAUTH_SCOPES),
+        cache_handler=cache_handler,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        show_dialog=True,
+    )
+    if request.args.get("code"):
+        # Step 2: Redirect from spotify back here.
+        auth_manager.get_access_token(request.args.get("code"))
+        return redirect("/login")
+
+
+@app.route("/logout")
+def logout():
+    """Discard the token from the current session, logging out the user."""
+    session.pop("token_info", None)
+    return redirect("/")
+
+
+@app.route("/info")
+@logged_in
+def info(spotify):
+    """Page describing information about the currently logged in user.
+
+    :param spotify: Current spotify OAuth session
+    """
+    return render_template(
+        "info.html",
+        display_name=spotify.me()["display_name"],
+    )
+
+
+@app.route("/playlists")
+@logged_in
+def playlists(spotify):
+    """Get all the playlists of the current user.
+
+    :param spotify: Current spotify OAuth session
+    """
+    return spotify.current_user_playlists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ and genres to gradually transition from various music styles to create a cohesiv
 listening experience."""
 # readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["flask ~= 2.2.2"]
+dependencies = [
+    "flask          ~= 2.2.2",
+    "flask-session2 ~= 1.3.1",
+    "python-dotenv  ~= 0.21.1",
+    "spotipy        ~= 2.22.0",
+]
 dynamic = ["version"]
 
 [tool.setuptools]


### PR DESCRIPTION
This PR
* Adds the `spotipy` library and some helper libraries for managing flask sessions as dependencies.
* Implements the OAuth code flow as described [here](https://developer.spotify.com/documentation/general/guides/authorization/code-flow/)
* Adds a sample page to test out some simple functionality.
* Adds a decorator to make adding more authenticated endpoints simple.

To test out this new functionality:
1. Install the newly added dependencies with: `pip install -e . --upgrade`
2. Create an application in the spotify developer dashboard, setting `http://localhost:5000/login_callback` as the redirect uri.
3. Create a file in the root of the repository called `.env` with the following contents:
  ```
  CLIENT_ID=CLIENT_ID_FROM_SPOTIFY_DEVELOPER_DASHBOARD
  CLIENT_SECRET=CLIENT_SECRET_FROM_SPOTIFY_DEVELOPER_DASHBOARD
  ```
4. Start the flask app as usual: `flask --debug --app SimmerTheToads run`
5. Navigate to `http://localhost:5000/login` with any web browser.

This should prompt you to login with your spotify account, then redirect you to a page where you can either logout or retrieve your playlists in JSON form.