### PR TITLE
Start of Playlist Engine

### DIFF
--- a/SimmerTheToads/engine.py
+++ b/SimmerTheToads/engine.py
@@ -1,0 +1,206 @@
+"""TODO."""
+import os
+from pprint import pprint
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from spotipy.client import Spotify
+
+# pd.set_option("display.max_rows", None)
+pd.set_option("display.max_columns", None)
+pd.set_option("display.width", None)
+
+
+class Track:
+    """Represent a single Spotify track."""
+
+    _metadata: dict
+    _features: dict
+    _analysis: dict
+    _spotify: Spotify
+
+    def __init__(self, spotify: Spotify, metadata: dict, features: dict):
+        self._metadata = metadata
+        self._features = features
+        self._features["track"] = self
+        self._spotify = spotify
+
+        self._get_analysis()
+
+    def _get_analysis(self):
+        self._analysis = {}
+        # TODO: This is really slow since there are so many API calls.
+        #       Maybe do this lazily?
+        # self._analysis = spotify.audio_analysis(self.id)
+
+    @property
+    def id(self):
+        """Get the Spotify ID of this track."""
+        return self._metadata["id"]
+
+    @property
+    def metadata(self):
+        """Get the raw metadata about this track."""
+        return self._metadata
+
+    @property
+    def features(self):
+        """Get the audio features about this track."""
+        return self._features
+
+    @property
+    def analysis(self):
+        """Get the audio analysis about this track."""
+        return self._analysis
+
+
+class Playlist:
+    """Represent a Spotify playlist."""
+
+    id: str
+    name: Optional[str]
+    df: pd.DataFrame
+
+    FEATURE_COLUMNS = [
+        "id",
+        "acousticness",
+        "analysis_url",
+        "danceability",
+        "duration_ms",
+        "energy",
+        "instrumentalness",
+        "key",
+        "liveness",
+        "loudness",
+        "mode",
+        "speechiness",
+        "tempo",
+        "time_signature",
+        "track_href",
+        "valence",
+        "track",
+    ]
+
+    def __init__(self, spotify, id, name=None):
+        self.id = id
+        self.name = name
+
+        # Retrieve all the tracks within the playlist
+        track_data = spotify.user_playlist_tracks(playlist_id=self.id)
+        track_ids = [i["track"]["id"] for i in track_data["items"]]
+
+        # Get all the features of each track within the playlist.
+        # Do this outside of the Track class to leverage the batched API.
+        features = spotify.audio_features(track_ids)
+
+        rows = []
+        for metadata, features in zip(track_data["items"], features):
+            t = Track(spotify, metadata["track"], features)
+            rows.append(t.features)
+
+        self.df = pd.DataFrame(rows, columns=self.FEATURE_COLUMNS)
+
+    def plot(self):
+        """Show some simple statistics about this playlist."""
+        nrows = 4
+        ncols = 3
+        fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(16, 12))
+        relevant_cols = [
+            "acousticness",
+            "danceability",
+            "duration_ms",
+            "energy",
+            "instrumentalness",
+            "key",
+            "liveness",
+            "loudness",
+            "mode",
+            "speechiness",
+            "tempo",
+            "time_signature",
+        ]
+
+        for i, v in enumerate(relevant_cols):
+            ax = axes[i % (ncols + 1)][i // nrows]
+            # sns.histplot(data=self.df, x=x, ax=ax)
+            #
+            # sns.boxplot(
+            #     data=self.df,
+            #     y=v,
+            #     ax=ax,
+            #     palette="husl",
+            # )
+            sns.histplot(
+                data=self.df,
+                x=v,
+                ax=ax,
+            )
+            # self.df.hist(column=x, ax=ax)
+
+        fig.suptitle(f"Playlist General Statistics: {self.name}")
+        fig.tight_layout()
+        plt.show()
+
+
+def simmer_playlist(
+    spotify: Spotify,
+    playlist_id: str,
+    playlist_name: Optional[str] = None,
+) -> list[Track]:
+    """
+    Reorder / add songs to playlist for simmering.
+
+    This is the main entrypoint to the playlist processing engine. It queries a
+    playlist for all the required information about a playlist, then reorders
+    the playlist. This aims to be an abstraction to avoid requiring the Spotify
+    API to be passed deep into the engine.
+
+    :param spotify: Current spotify OAuth session
+    :param playlist_id: ID of the playlist to simmer.
+    """
+    # playlists = spotify.current_user_playlists()
+    # playlists = sort_playlists_by_id(playlists)
+    # playlist = playlists[playlist_id]
+    # pprint(playlist)
+
+    # TODO: This will need to handle the pagination eventually
+    #       Currently, this will only handle the first 100 songs.
+    #       Also, beware the rate limit...
+    p = Playlist(spotify, playlist_id, playlist_name)
+    p.plot()
+    # p.df.plot()
+
+
+if __name__ == "__main__":
+    # For the sake of testing without spinning up the entire web application.
+    import spotipy
+    from dotenv import load_dotenv
+    from spotipy.oauth2 import SpotifyOAuth
+
+    load_dotenv()
+
+    CLIENT_ID = os.getenv("CLIENT_ID")
+    CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+    REDIRECT_URI = "http://localhost:5000/login_callback"
+    OAUTH_SCOPES = [
+        "playlist-read-private",
+        "playlist-read-collaborative",
+        "playlist-modify-private",
+        "playlist-modify-public",
+    ]
+
+    auth_manager = SpotifyOAuth(
+        scope=" ".join(OAUTH_SCOPES),
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        show_dialog=True,
+    )
+
+    spotify = spotipy.Spotify(auth_manager=auth_manager)
+
+    playlist_name = "Josh's Jar of Samys"
+    playlist_id = "3Wh0AUvdYEg6fz0zmpwaH6"
+    simmer_playlist(spotify, playlist_id, playlist_name)

--- a/SimmerTheToads/engine.py
+++ b/SimmerTheToads/engine.py
@@ -59,6 +59,7 @@ class Track:
 class Playlist:
     """Represent a Spotify playlist."""
 
+    metadata: dict
     id: str
     name: Optional[str]
     df: pd.DataFrame
@@ -83,9 +84,9 @@ class Playlist:
         "track",
     ]
 
-    def __init__(self, spotify, id, name=None):
+    def __init__(self, spotify, id):
         self.id = id
-        self.name = name
+        self.metadata = spotify.playlist(id)
 
         # Retrieve all the tracks within the playlist
         track_data = spotify.user_playlist_tracks(playlist_id=self.id)
@@ -128,21 +129,23 @@ class Playlist:
         ]
 
         for i, v in enumerate(relevant_cols):
-            ax = lineplots_axes[i % (ncols + 1)][i // nrows]
-            sns.lineplot(data=self.df, x=self.df.index, y=v, ax=ax)
-
-        for i, v in enumerate(relevant_cols):
-            ax = distplots_axes[i % (ncols + 1)][i // nrows]
+            sns.lineplot(
+                data=self.df,
+                x=self.df.index,
+                y=v,
+                ax=lineplots_axes[i % (ncols + 1)][i // nrows],
+                markers=True,
+            )
             sns.histplot(
                 data=self.df,
                 x=v,
-                ax=ax,
+                ax=distplots_axes[i % (ncols + 1)][i // nrows],
             )
 
-        lineplots_fig.suptitle(f"{self.name}")
+        lineplots_fig.suptitle(f"{self.metadata['name']}")
         lineplots_fig.tight_layout()
 
-        distplots_fig.suptitle(f"{self.name}")
+        distplots_fig.suptitle(f"{self.metadata['name']}")
         distplots_fig.tight_layout()
         plt.show()
 
@@ -150,7 +153,6 @@ class Playlist:
 def simmer_playlist(
     spotify: Spotify,
     playlist_id: str,
-    playlist_name: Optional[str] = None,
 ) -> list[Track]:
     """
     Reorder / add songs to playlist for simmering.
@@ -166,7 +168,7 @@ def simmer_playlist(
     # TODO: This will need to handle the pagination eventually
     #       Currently, this will only handle the first 100 songs.
     #       Also, beware the rate limit...
-    p = Playlist(spotify, playlist_id, playlist_name)
+    p = Playlist(spotify, playlist_id)
     p.plot()
 
 
@@ -198,6 +200,15 @@ if __name__ == "__main__":
 
     spotify = spotipy.Spotify(auth_manager=auth_manager)
 
-    playlist_name = "Josh's Jar of Samys"
-    playlist_id = "3Wh0AUvdYEg6fz0zmpwaH6"
-    simmer_playlist(spotify, playlist_id, playlist_name)
+    playlists = {
+        "Abbey Road": "2CPPiUTAtfvaeAEyWApOSE",
+        "Fiddler on the roof": "3engsNaAr6Q9cTT85gKCGd",
+        "Josh's Jar of Samys": "3Wh0AUvdYEg6fz0zmpwaH6",
+        "Lona and Josh's Code Think Tank": "0GJIoDOUsoSS2IDWniCTqP",
+        "The Big Bach": "4OFbt8ZZOhE0oZcC4GGBMO",
+        "godawful amalgamation": "0KOMGaR3mgeymmUBoN0ZlQ",
+        "close but no cigar": "78C62xSuql1V2jwMvonI4N",
+        "manic pixel dream girl complex": "3ZL5feDBYxJSWR6zg7EDeu",
+    }
+
+    simmer_playlist(spotify, playlists["manic pixel dream girl complex"])

--- a/SimmerTheToads/engine.py
+++ b/SimmerTheToads/engine.py
@@ -106,7 +106,12 @@ class Playlist:
         """Show some simple statistics about this playlist."""
         nrows = 4
         ncols = 3
-        fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(16, 12))
+        lineplots_fig, lineplots_axes = plt.subplots(
+            nrows=nrows, ncols=ncols, figsize=(16, 12)
+        )
+        distplots_fig, distplots_axes = plt.subplots(
+            nrows=nrows, ncols=ncols, figsize=(16, 12)
+        )
         relevant_cols = [
             "acousticness",
             "danceability",
@@ -123,24 +128,22 @@ class Playlist:
         ]
 
         for i, v in enumerate(relevant_cols):
-            ax = axes[i % (ncols + 1)][i // nrows]
-            # sns.histplot(data=self.df, x=x, ax=ax)
-            #
-            # sns.boxplot(
-            #     data=self.df,
-            #     y=v,
-            #     ax=ax,
-            #     palette="husl",
-            # )
+            ax = lineplots_axes[i % (ncols + 1)][i // nrows]
+            sns.lineplot(data=self.df, x=self.df.index, y=v, ax=ax)
+
+        for i, v in enumerate(relevant_cols):
+            ax = distplots_axes[i % (ncols + 1)][i // nrows]
             sns.histplot(
                 data=self.df,
                 x=v,
                 ax=ax,
             )
-            # self.df.hist(column=x, ax=ax)
 
-        fig.suptitle(f"Playlist General Statistics: {self.name}")
-        fig.tight_layout()
+        lineplots_fig.suptitle(f"{self.name}")
+        lineplots_fig.tight_layout()
+
+        distplots_fig.suptitle(f"{self.name}")
+        distplots_fig.tight_layout()
         plt.show()
 
 
@@ -160,17 +163,11 @@ def simmer_playlist(
     :param spotify: Current spotify OAuth session
     :param playlist_id: ID of the playlist to simmer.
     """
-    # playlists = spotify.current_user_playlists()
-    # playlists = sort_playlists_by_id(playlists)
-    # playlist = playlists[playlist_id]
-    # pprint(playlist)
-
     # TODO: This will need to handle the pagination eventually
     #       Currently, this will only handle the first 100 songs.
     #       Also, beware the rate limit...
     p = Playlist(spotify, playlist_id, playlist_name)
     p.plot()
-    # p.df.plot()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,17 @@ name = "SimmerTheToads"
 description = """Simmer The Toads aims to refine playlists of varying artists
 and genres to gradually transition from various music styles to create a cohesive
 listening experience."""
-# readme = "README.md"
+readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "flask          ~= 2.2.2",
     "flask-session2 ~= 1.3.1",
+    "matplotlib     ~= 3.6.3",
+    "numpy          ~= 1.24.1",
+    "pandas         ~= 1.5.3",
     "python-dotenv  ~= 0.21.1",
+    "scipy          ~= 1.10.0",
+    "seaborn        ~= 0.12.2",
     "spotipy        ~= 2.22.0",
 ]
 dynamic = ["version"]
@@ -22,3 +27,6 @@ packages = ["SimmerTheToads"]
 
 [tool.setuptools.dynamic]
 version = { attr = "SimmerTheToads.__version__" }
+
+[tool.pydocstyle]
+add_ignore = ["D107"]


### PR DESCRIPTION
This PR
* Adds some helper classes to abstract away Spotify API interactions.
* Adds the boilerplate to query playlists and song details from Spotify (into a `pandas` dataframe).
* Adds many depedencies for analyzing the data about each track.
* Adds some auxiliary plotting functions to visualize.

Sample plots for [this playlist](https://open.spotify.com/playlist/3Wh0AUvdYEg6fz0zmpwaH6?si=923b7c0328004890):
![Figure_2](https://user-images.githubusercontent.com/14321139/214123881-af0d40e5-a5ce-4127-a576-15fb9b21ca52.png)
![Figure_1](https://user-images.githubusercontent.com/14321139/214123888-e622d7e0-19b7-4f78-a5fa-ce31c0de00b6.png)

