### PR TITLE
Add parallelization for playlist analytics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.8"
 dependencies = [
     "flask          ~= 2.2.2",
     "flask-session2 ~= 1.3.1",
+    "joblib         ~= 1.2.0",
     "matplotlib     ~= 3.6.3",
     "numpy          ~= 1.24.1",
     "pandas         ~= 1.5.3",


### PR DESCRIPTION
Spotify's analysis data for tracks is extremely detailed, but unfortunately there is no batched API to fetch all this information quickly. Thus, we resort to manually querying the API many times to retrieve this information sequentially. This is usually very slow, since the overhead from the repeated API calls adds up quickly. The obvious solution is to parallelize this and perform all these transactions concurrently.

This commit implements concurrent retrieval of analysis data for all tracks within a playlist. Some quick testing shows significant speedups:

Pre:
```
real    2m1.423s
user    0m9.112s
sys     0m3.228s
```

Post:
```
real    0m26.849s
user    0m11.894s
sys     0m3.601s
```

All testing was done with a playlist of 328 items, likely much larger than what we are going to encounter for day-to-day users, so hopefully this current solution is fast enough going forward.