### PR TITLE
Implement clustering for song grouping

### DIFF
--- a/SimmerTheToads/engine.py
+++ b/SimmerTheToads/engine.py
@@ -13,7 +13,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from sklearn.cluster import AgglomerativeClustering, KMeans, SpectralClustering
 from sklearn.decomposition import PCA
-from sklearn.preprocessing import LabelEncoder, StandardScaler
+from sklearn.preprocessing import LabelEncoder, RobustScaler, StandardScaler
 from spotipy.client import Spotify
 
 pd.set_option("display.max_columns", None)
@@ -378,7 +378,7 @@ class ClusteringEvaluator(PlaylistEvaluatorBase):
         numeric_df = df.select_dtypes(include=[np.number])
         arr = numeric_df.to_numpy()
         scaler = StandardScaler()
-        scaled = scaler.fit_transform(arr)
+        scaled = scaler.fit_transform(RobustScaler().fit_transform(arr))
 
         # Add artists column, exclude this from scaling
         scaled = np.append(scaled, artists, axis=1)
@@ -400,7 +400,7 @@ class ClusteringEvaluator(PlaylistEvaluatorBase):
         # Get some initial distances to help guide our search
         clustering = AgglomerativeClustering(
             n_clusters=None,
-            distance_threshold=7,
+            distance_threshold=12,
         )
         labels = clustering.fit_predict(features_matrix)
 
@@ -436,11 +436,11 @@ def simmer_playlist(
     e = evaluator(p)
     e.reorder()
 
-    p.plot(
-        fmt_title="{{name}}: Reordered by {feature}".format(
-            feature=evaluator.__name__,
-        )
-    )
+    # p.plot(
+    #     fmt_title="{{name}}: Reordered by {feature}".format(
+    #         feature=evaluator.__name__,
+    #     )
+    # )
     print(p.df)
 
     # Propogate local changes back to spotify playlist
@@ -497,7 +497,7 @@ if __name__ == "__main__":
     }
 
     cache_path = Path("./playlist.pickle")
-    p = Playlist(spotify, playlists["mainstream"])
+    p = Playlist(spotify, playlists["4 cat copy"])
     # if cache_path.is_file():
     #     with open(cache_path, "rb") as f:
     #         p = pickle.load(f)
@@ -509,5 +509,5 @@ if __name__ == "__main__":
     simmer_playlist(
         p,
         ClusteringEvaluator,
-        to_spotify=False,
+        to_spotify=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "numpy          ~= 1.24.1",
     "pandas         ~= 1.5.3",
     "python-dotenv  ~= 0.21.1",
+    "scikit-learn   ~= 1.21.0",
     "scipy          ~= 1.10.0",
     "seaborn        ~= 0.12.2",
     "spotipy        ~= 2.22.0",


### PR DESCRIPTION
Most songs within a playlist typically fit within some homogeneous group.
To effectively evaluate where songs should be added, we need to find these groups.
In this PR, agglomerative clustering is added to sort playlists.

New pipeline of playlist analysis:

1. Grab as much metadata and audio analysis about each track from Spotify as possible.
2. Drop all data which has a confidence rating less than 70%.
3. Encode categorical features as ordinal values (ex. artists as a numerical index).
4. Apply [robust scaling](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.RobustScaler.html), then [min max scaling](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html) on all non-ordinal features.
5. Use [PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) to reduce the number of features.
6. Apply agglomerative clustering.
7. Order the songs by cluster (somewhat unnecessary due to step 9).
8. Order the songs within clusters:
   - Compute an euclidean distance matrix summing across all features within a cluster.
   - Compute an optimal (or approximate) TSP tour.
   - Reorder the tracks to match this tour.
9. Order the clusters:
   - Compute an euclidean distance matrix of the clusters where distance equals the euclidean distance between the last track of one cluster and the first track of another cluster.
   - Compute an optimal (or approximate) TSP tour.
   - Reorder the clusters to match this tour.
10. Write the result back to Spotify.

Aside from these algorithmic additions, this PR adds many helpful plotting utilities and abstracts the entire evaluator engine. These improvements (hopefully) make it trivial to swap to an entirely different evaluator later down the line if we need to.
