### PR TITLE
Proposal: Amend MVP to leverage what is already done.

### DIFF
--- a/details-context/minViable.md
+++ b/details-context/minViable.md
@@ -1,10 +1,19 @@
-This is our minimum viable project
+# Minimum Viable Product
 
-Our minimum viable product includes:
-- A webpage to get songs
-  - input songs
-- Analysis of songs
-  - get meta information
-  - make decision about adding songs or not
-- Add songs
-- Output playlist (list of songs)
+## User Interface - Frontend
+
+A website with the following core components:
+
+- A login with Spotify button/link.
+- List/table of all the current user's playlists.
+- Ability to select a playlist and request reordering ('simmering').
+- A way to view the resulting playlist and to confirm whether or not to write
+  the changes back to the original Spotify playlist.
+
+## Playlist Evaluator and REST API - Backend
+
+- Maintain Spotify login state for users.
+- Retrieve all playlists from the current user.
+- Analyze an existing playlist, reorder, and optionally add songs.
+- Output the result in some serializable fashion and optionally write the
+  changes back to the original Spotify playlist.


### PR DESCRIPTION
So far we have a fully functional playlist evaluator leveraging the Spotify playlist API.

I propose that we amend our MVP to utilize an existing playlist first, instead of manually creating one from the frontend. The new user flow would look something like: 
1. User navigates to our webpage.
2. User logs in with Spotify
3. User selects playlist to be reordered.
4. We reorder the playlist and ask for confirmation to modify the original playlist.
5. Profit?

Following this new scheme has the following advantages:

* Since all the necessary Spotify authentication details are nearly complete, and the backend is already capable of evaluating playlists, we could have a working and demo-able webpage much sooner.
* We can add more features going forward with more confidence, since we would already have something presentable.
* We can debug frontend/backend integration issues sooner.
* More time can be spent on 'prettifying' the user interface if we have a playlist 'simmering' flow completed earlier.


 Given our current progress, I think this new MVP is more attainable.