### PR TITLE
Add Song Suggestions

### DIFF
--- a/SimmerTheToads/__init__.py
+++ b/SimmerTheToads/__init__.py
@@ -1,5 +1,6 @@
 """Entrypoint to flask full-stack application."""
 
+import logging
 import secrets
 from pathlib import Path
 
@@ -12,15 +13,18 @@ load_dotenv()
 
 LINE = "=" * 80
 
+# Setup the logger
+LOG_LEVEL = logging.INFO
+format_ = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+logging.basicConfig(format=format_, level=LOG_LEVEL)
+logger = logging.getLogger("SimmerTheToads")
 
 # Paths for production deployments
 template_dir = Path("./frontend/build")
 static_dir = template_dir / "static/"
 
-
-print(LINE)
-print(f"{template_dir.absolute()=}")
-print(f"{static_dir.absolute()=}")
+logger.info("Template directory: %s", template_dir.absolute())
+logger.info("Static directory: %s", static_dir.absolute())
 
 app = Flask(
     __name__,


### PR DESCRIPTION
This PR:

  * Adds song suggestions to all engines. By default playlist simmering follows this procedure:
    1. Reorder using whatever evaluator specific method (clustering, TSP, chaos etc.).
    2. Locate regions for suggestions by computing the hamming distance (or some other distance function) of pairs of tracks and selecting the maximum distances. 
    3. For each region with large distance:
       a. Average all the features of the two songs.
       b. Send all the features and the two songs themselves to the recommendation API.
       c. Retrieve the top 3 results from the recommmendation api, and select the track which minimizes the TSP tour among these three songs.
    4. Reassemble the playlist with these new songs added.
    5. Optionally write the result back to spotify.
  * Adds some basic logging facilities to make debugging easier as we scale.
  * Cleanup a lot of the suggestion and reording code.
  * Adds the option to select a specific playlist evaluator from the REST API.
  
Hopefully there are no regressions, since so much code had to change for these additions. Overall, there is a relatively small performance penalty for all these additions. The majority of the evaluation runtime is still taken up by sequential calls to the Spotify analysis API. If we have enough time, we should port all the API interactions to some sort of async runtime for a sizeable performance gain, but that is a reach goal for another time. With this PR (minus any bug fixes) all the backend playlist functionality for the MVP should be implemented.
